### PR TITLE
Fix `Behavior` and `Handler` lifetimes

### DIFF
--- a/src/Immediate.Handlers.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Immediate.Handlers.Analyzers/AnalyzerReleases.Unshipped.md
@@ -7,7 +7,6 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
 IHR0001 | ImmediateHandler | Error    | HandlerClassAnalyzer
 IHR0002 | ImmediateHandler | Error    | HandlerClassAnalyzer
-IHR0003 | ImmediateHandler | Error    | BehaviorsAnalyzer
 IHR0004 | ImmediateHandler | Error    | RenderModeAnalyzer
 IHR0005 | ImmediateHandler | Error    | HandlerClassAnalyzer
 IHR0006 | ImmediateHandler | Error    | BehaviorsAnalyzer

--- a/src/Immediate.Handlers.Analyzers/BehaviorsAnalyzer.cs
+++ b/src/Immediate.Handlers.Analyzers/BehaviorsAnalyzer.cs
@@ -9,17 +9,6 @@ namespace Immediate.Handlers.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class BehaviorsAnalyzer : DiagnosticAnalyzer
 {
-	private static readonly DiagnosticDescriptor BehaviorsMustNotBeRepeated =
-		new(
-			id: DiagnosticIds.IHR0003BehaviorsMustNotBeRepeated,
-			title: "Behaviors must not be repeated",
-			messageFormat: "Behavior type '{0}' must be used only once",
-			category: "ImmediateHandler",
-			defaultSeverity: DiagnosticSeverity.Error,
-			isEnabledByDefault: true,
-			description: "Behaviors may not be used more than once in a single pipeline."
-		);
-
 	private static readonly DiagnosticDescriptor BehaviorsMustInheritFromBehavior =
 		new(
 			id: DiagnosticIds.IHR0006BehaviorsMustInheritFromBehavior,
@@ -56,7 +45,6 @@ public sealed class BehaviorsAnalyzer : DiagnosticAnalyzer
 	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
 		ImmutableArray.Create<DiagnosticDescriptor>(
 		[
-			BehaviorsMustNotBeRepeated,
 			BehaviorsMustInheritFromBehavior,
 			BehaviorsMustHaveTwoGenericParameters,
 			BehaviorsMustUseUnboundGenerics,
@@ -113,7 +101,6 @@ public sealed class BehaviorsAnalyzer : DiagnosticAnalyzer
 		if (baseBehaviorSymbol is null)
 			return;
 
-		var seenBehaviors = new HashSet<string>();
 		foreach (var op in aio.ChildOperations)
 		{
 			token.ThrowIfCancellationRequested();
@@ -155,16 +142,6 @@ public sealed class BehaviorsAnalyzer : DiagnosticAnalyzer
 				context.ReportDiagnostic(
 					Diagnostic.Create(
 						BehaviorsMustUseUnboundGenerics,
-						location,
-						originalDefinition.Name)
-				);
-			}
-
-			if (!seenBehaviors.Add(originalDefinition.ToString()))
-			{
-				context.ReportDiagnostic(
-					Diagnostic.Create(
-						BehaviorsMustNotBeRepeated,
 						location,
 						originalDefinition.Name)
 				);

--- a/src/Immediate.Handlers.Analyzers/DiagnosticIds.cs
+++ b/src/Immediate.Handlers.Analyzers/DiagnosticIds.cs
@@ -7,7 +7,6 @@ internal static class DiagnosticIds
 {
 	public const string IHR0001HandlerMethodMustExist = "IHR0001";
 	public const string IHR0002HandlerMethodMustReturnTask = "IHR0002";
-	public const string IHR0003BehaviorsMustNotBeRepeated = "IHR0003";
 	public const string IHR0004InvalidRenderMode = "IHR0004";
 	public const string IHR0005HandlerClassMustNotBeNested = "IHR0005";
 	public const string IHR0006BehaviorsMustInheritFromBehavior = "IHR0006";

--- a/src/Immediate.Handlers.Analyzers/Immediate.Handlers.Analyzers.md
+++ b/src/Immediate.Handlers.Analyzers/Immediate.Handlers.Analyzers.md
@@ -24,18 +24,6 @@ Handler methods must return a `ValueTask<T>`
 | CodeFix  | False            |
 ---
 
-## IHR0003: Behaviors must not be repeated in a pipeline
-
-Behaviors are not reentrant, and must not be specified more than once in a single pipeline. 
-
-|Item|Value|
-|-|-|
-|Category|ImmediateHandler|
-|Enabled|True|
-|Severity|Error|
-|CodeFix|False|
----
-
 ## IHR0004: RenderMode attribute must be set to a valid RenderMode
 
 An invalid value on the `RenderMode` attribute on the assembly or a Handler is unsupported and will lead to compilation

--- a/src/Immediate.Handlers.Generators/ImmediateHandlers/ImmediateHandlersGenerator_TransformBehaviors.cs
+++ b/src/Immediate.Handlers.Generators/ImmediateHandlers/ImmediateHandlersGenerator_TransformBehaviors.cs
@@ -39,7 +39,6 @@ public partial class ImmediateHandlersGenerator
 		if (!SymbolEqualityComparer.Default.Equals(ca.Type, arrayTypeSymbol))
 			return [];
 
-		var seenBehaviors = new HashSet<string>();
 		cancellationToken.ThrowIfCancellationRequested();
 		return ca.Values
 			.Select(v =>
@@ -59,9 +58,6 @@ public partial class ImmediateHandlersGenerator
 					return null;
 
 				if (!originalDefinition.ImplementsBaseClass(behaviorTypeSymbol))
-					return null;
-
-				if (!seenBehaviors.Add(originalDefinition.ToString()))
 					return null;
 
 				cancellationToken.ThrowIfCancellationRequested();

--- a/src/Immediate.Handlers.Generators/Templates/Handler.sbntxt
+++ b/src/Immediate.Handlers.Generators/Templates/Handler.sbntxt
@@ -106,13 +106,14 @@ partial class {{ class_name }}
 	{{~ if has_ms_di ~}}
 
 	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddHandlers(
-		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
+	public static IServiceCollection AddHandlers(
+		IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
 	)
 	{
-		services.AddScoped<{{ class_fully_qualified_name }}.Handler>();
-		services.AddScoped<global::Immediate.Handlers.Shared.IHandler<{{ request_type }}, {{ response_type }}>, {{ class_fully_qualified_name }}.Handler>();
-		services.AddScoped<{{ class_fully_qualified_name }}.HandleBehavior>();
+		services.Add(new(typeof({{ class_fully_qualified_name }}.Handler), typeof({{ class_fully_qualified_name }}.Handler), lifetime));
+		services.Add(new(typeof(global::Immediate.Handlers.Shared.IHandler<{{ request_type }}, {{ response_type }}>), typeof({{ class_fully_qualified_name }}.Handler), lifetime));
+		services.Add(new(typeof({{ class_fully_qualified_name }}.HandleBehavior), typeof({{ class_fully_qualified_name }}.HandleBehavior), lifetime));
 		return services;
 	}
 	{{~ end ~}}

--- a/src/Immediate.Handlers.Generators/Templates/ServiceCollectionExtensions.sbntxt
+++ b/src/Immediate.Handlers.Generators/Templates/ServiceCollectionExtensions.sbntxt
@@ -8,21 +8,23 @@ namespace {{ namespace }};
 {{~ end ~}}
 public static class HandlerServiceCollectionExtensions
 {
-	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddBehaviors(
-		this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+	public static IServiceCollection AddBehaviors(
+		this IServiceCollection services)
 	{
 		{{~ for b in behaviors ~}}
-		services.AddScoped(typeof({{ b.registration_type }}));
+		services.AddTransient(typeof({{ b.registration_type }}));
 		{{~ end ~}}
 		
 		return services;
 	}
 
-	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddHandlers(
-		this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+	public static IServiceCollection AddHandlers(
+		this IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
 	{
 		{{~ for h in handlers ~}}
-		{{ h }}.AddHandlers(services);
+		{{ h }}.AddHandlers(services, lifetime);
 		{{~ end ~}}
 		
 		return services;

--- a/tests/Immediate.Handlers.FunctionalTests/MultipleBehaviors/MultipleBehaviorsTests.cs
+++ b/tests/Immediate.Handlers.FunctionalTests/MultipleBehaviors/MultipleBehaviorsTests.cs
@@ -36,7 +36,8 @@ public class Behavior2<TRequest, TResponse> : Behavior<TRequest, TResponse>
 [Handler]
 [Behaviors(
 	typeof(Behavior1<,>),
-	typeof(Behavior2<,>)
+	typeof(Behavior2<,>),
+	typeof(Behavior1<,>)
 )]
 public static partial class MultipleBehaviorHandler
 {
@@ -58,7 +59,7 @@ public sealed class MultipleBehaviorsTests
 	{
 		var query = new MultipleBehaviorHandler.Query();
 		var handler = new MultipleBehaviorHandler.Handler(
-			new(), new(), new());
+			new(), new(), new(), new());
 
 		_ = await handler.HandleAsync(query);
 
@@ -66,7 +67,9 @@ public sealed class MultipleBehaviorsTests
 			[
 				"Behavior1.Enter",
 				"Behavior2.Enter",
+				"Behavior1.Enter",
 				"Query.HandleAsync",
+				"Behavior1.Exit",
 				"Behavior2.Exit",
 				"Behavior1.Exit",
 			],

--- a/tests/Immediate.Handlers.Tests/AnalyzerTests/BehaviorAnalyzerTests/Tests.BehaviorTypeIsUsedMoreThanOnce.cs
+++ b/tests/Immediate.Handlers.Tests/AnalyzerTests/BehaviorAnalyzerTests/Tests.BehaviorTypeIsUsedMoreThanOnce.cs
@@ -22,7 +22,7 @@ public partial class Tests
 
 			[assembly: Behaviors(
 				typeof(LoggingBehavior<,>),
-				typeof({|IHR0003:LoggingBehavior<,>|})
+				typeof(LoggingBehavior<,>)
 			)]
 
 			namespace Normal;
@@ -54,7 +54,7 @@ public partial class Tests
 			[Handler]
 			[Behaviors(
 				typeof(LoggingBehavior<,>),
-				typeof({|IHR0003:LoggingBehavior<,>|})
+				typeof(LoggingBehavior<,>)
 			)]
 			public static partial class GetUsersQuery
 			{

--- a/tests/Immediate.Handlers.Tests/GeneratorTests/Behaviors/MultipleBehaviorTest.MultipleBehaviors_assemblies=Msdi#Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Handlers.Tests/GeneratorTests/Behaviors/MultipleBehaviorTest.MultipleBehaviors_assemblies=Msdi#Dummy.GetUsersQuery.g.verified.cs
@@ -78,13 +78,14 @@ partial class GetUsersQuery
 	}
 
 	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddHandlers(
-		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
+	public static IServiceCollection AddHandlers(
+		IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
 	)
 	{
-		services.AddScoped<global::Dummy.GetUsersQuery.Handler>();
-		services.AddScoped<global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, IEnumerable<global::Dummy.User>>, global::Dummy.GetUsersQuery.Handler>();
-		services.AddScoped<global::Dummy.GetUsersQuery.HandleBehavior>();
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.Handler), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, IEnumerable<global::Dummy.User>>), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.HandleBehavior), typeof(global::Dummy.GetUsersQuery.HandleBehavior), lifetime));
 		return services;
 	}
 }

--- a/tests/Immediate.Handlers.Tests/GeneratorTests/Behaviors/MultipleBehaviorTest.MultipleBehaviors_assemblies=Msdi#ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Handlers.Tests/GeneratorTests/Behaviors/MultipleBehaviorTest.MultipleBehaviors_assemblies=Msdi#ServiceCollectionExtensions.g.verified.cs
@@ -5,22 +5,24 @@ using Microsoft.Extensions.DependencyInjection;
 
 public static class HandlerServiceCollectionExtensions
 {
-	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddBehaviors(
-		this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+	public static IServiceCollection AddBehaviors(
+		this IServiceCollection services)
 	{
-		services.AddScoped(typeof(global::Dummy.LoggingBehavior<,>));
-		services.AddScoped(typeof(global::YetAnotherDummy.OtherBehavior<,>));
-		services.AddScoped(typeof(global::Dummy.SecondLoggingBehavior<,>));
-		services.AddScoped(typeof(global::YetAnotherDummy.LoggingBehavior<,>));
-		services.AddScoped(typeof(global::YetAnotherDummy.SecondLoggingBehavior<,>));
+		services.AddTransient(typeof(global::Dummy.LoggingBehavior<,>));
+		services.AddTransient(typeof(global::YetAnotherDummy.OtherBehavior<,>));
+		services.AddTransient(typeof(global::Dummy.SecondLoggingBehavior<,>));
+		services.AddTransient(typeof(global::YetAnotherDummy.LoggingBehavior<,>));
+		services.AddTransient(typeof(global::YetAnotherDummy.SecondLoggingBehavior<,>));
 		
 		return services;
 	}
 
-	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddHandlers(
-		this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+	public static IServiceCollection AddHandlers(
+		this IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
 	{
-		global::Dummy.GetUsersQuery.AddHandlers(services);
+		global::Dummy.GetUsersQuery.AddHandlers(services, lifetime);
 		
 		return services;
 	}

--- a/tests/Immediate.Handlers.Tests/GeneratorTests/Behaviors/SingleBehaviorTest.SingleBehavior_assemblies=Msdi#Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Handlers.Tests/GeneratorTests/Behaviors/SingleBehaviorTest.SingleBehavior_assemblies=Msdi#Dummy.GetUsersQuery.g.verified.cs
@@ -62,13 +62,14 @@ partial class GetUsersQuery
 	}
 
 	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddHandlers(
-		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
+	public static IServiceCollection AddHandlers(
+		IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
 	)
 	{
-		services.AddScoped<global::Dummy.GetUsersQuery.Handler>();
-		services.AddScoped<global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, IEnumerable<global::Dummy.User>>, global::Dummy.GetUsersQuery.Handler>();
-		services.AddScoped<global::Dummy.GetUsersQuery.HandleBehavior>();
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.Handler), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Immediate.Handlers.Shared.IHandler<global::Dummy.GetUsersQuery.Query, IEnumerable<global::Dummy.User>>), typeof(global::Dummy.GetUsersQuery.Handler), lifetime));
+		services.Add(new(typeof(global::Dummy.GetUsersQuery.HandleBehavior), typeof(global::Dummy.GetUsersQuery.HandleBehavior), lifetime));
 		return services;
 	}
 }

--- a/tests/Immediate.Handlers.Tests/GeneratorTests/Behaviors/SingleBehaviorTest.SingleBehavior_assemblies=Msdi#ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Handlers.Tests/GeneratorTests/Behaviors/SingleBehaviorTest.SingleBehavior_assemblies=Msdi#ServiceCollectionExtensions.g.verified.cs
@@ -5,18 +5,20 @@ using Microsoft.Extensions.DependencyInjection;
 
 public static class HandlerServiceCollectionExtensions
 {
-	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddBehaviors(
-		this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+	public static IServiceCollection AddBehaviors(
+		this IServiceCollection services)
 	{
-		services.AddScoped(typeof(global::Dummy.LoggingBehavior<,>));
+		services.AddTransient(typeof(global::Dummy.LoggingBehavior<,>));
 		
 		return services;
 	}
 
-	public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddHandlers(
-		this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+	public static IServiceCollection AddHandlers(
+		this IServiceCollection services,
+		ServiceLifetime lifetime = ServiceLifetime.Scoped
+	)
 	{
-		global::Dummy.GetUsersQuery.AddHandlers(services);
+		global::Dummy.GetUsersQuery.AddHandlers(services, lifetime);
 		
 		return services;
 	}


### PR DESCRIPTION
This PR:
* Forces `Behavior` registration to be `Transient`
* Allows specifying handler registration lifetime
* Removes IHR0003 Analyzer

Fixes #29 
Fixes #30 